### PR TITLE
fix: remove tau from Optuna search space (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.0] — 2026-05-02
+
+### Changed
+- **tau removed from Optuna search space** — optimising tau alongside eps/k
+  created a circular reward: low tau makes `search_batch` behave like pure
+  cosine retrieval, which scores highest under the spectral MRR proxy. The
+  optimiser collapsed tau to its lower bound (≈ 0.11) regardless of corpus
+  geometry, nearly disabling the spectral component of ArrowSpace search.
+- `StudyConfig`: `tau_low` / `tau_high` fields replaced by `search_tau: float`
+  (default `0.5`). The fixed tau is passed to `search_batch` inside every
+  trial but is not a parameter Optuna can vary.
+- `EpsTuner.__init__`: `tau_low` / `tau_high` kwargs removed; `search_tau`
+  kwarg added (default `0.5`). `tuner.search_tau` attribute exposed so users
+  can pass it directly to `aspace.search()` after `fit()`.
+- `EpsTuner.best_params`: no longer contains `tau` (only `eps` and `k`).
+- `api.optuna()`: `tau_low` / `tau_high` params removed; `search_tau` added.
+- `__repr__`: updated to reflect new interface.
+- Warm-start anchor trial updated — `tau` key removed from enqueued params.
+- Log line updated — tau logged as `search_tau` (fixed constant, not trial value).
+- `user_attrs` in trial: `tau` key renamed to `search_tau` for clarity.
+- `DEFAULT_SEARCH_TAU = 0.5` constant added to `config.py` as single source
+  of truth for the default.
+
+### Migration
+If you were passing `tau_low` / `tau_high` to `EpsTuner` or `arrowspace_tuner.optuna()`,
+remove those arguments. If you relied on `tuner.best_params["tau"]`, use
+`tuner.search_tau` instead. Pass the same value to `aspace.search(gl, tau=tuner.search_tau)`.
+
+---
+
 ## [0.2.1] — 2026-05-02
 
 ### Changed

--- a/src/arrowspace_tuner/api.py
+++ b/src/arrowspace_tuner/api.py
@@ -1,18 +1,15 @@
 """
 api.py — one-liner convenience function for hyperparameter discovery.
 
-This module exists solely to satisfy the acceptance criteria:
+    aspace, gl = arrowspace_tuner.optuna(embeddings)
 
-    aspace, gl = arrowspace.optuna(embeddings)
-
-It is a thin shim over EpsTuner with sensible defaults.
-For any non-trivial use case, instantiate EpsTuner directly.
+Thin shim over EpsTuner with sensible defaults.
 """
 from __future__ import annotations
 
 import numpy as np
 
-from .core.config import _DEFAULT_N_TRIALS
+from .core.config import _DEFAULT_N_TRIALS, DEFAULT_SEARCH_TAU
 from .tuner import EpsTuner
 
 
@@ -28,22 +25,16 @@ def optuna(
     eps_high:   float      = 4.0,
     k_low:      int        = 3,
     k_high:     int        = 40,
-    tau_low:    float      = 0.1,
-    tau_high:   float      = 1.0,
+    search_tau: float      = DEFAULT_SEARCH_TAU,
     n_probe:    int        = 50,
 ) -> tuple[object, object]:
     """
-    Auto-discover eps, k, and tau and return a ready-to-use (aspace, gl) pair.
+    Auto-discover eps and k and return a ready-to-use (aspace, gl) pair.
 
-    This is the simplest entry point to arrowspace_tuner. It runs an Optuna
-    study with default settings and returns the ArrowSpace index built with
-    the best hyperparameters found.
-
-    Defaults are tuned for speed on large corpora (> 50k items):
-    - sample_n=5_000 gives a 33x speedup over full-corpus trials with
-      identical best params found (validated on a 50k CVE corpus).
-    - n_probe=50 is sufficient to rank parameter regions reliably.
-    - The final build after the study always uses the full corpus.
+    tau is NOT optimised — it is a search-time parameter that controls the
+    spectral/cosine blend in search_batch(). Pass ``search_tau`` here to
+    set the value used during the study; then pass the same value to
+    aspace.search() / aspace.search_batch() at query time.
 
     Parameters
     ----------
@@ -53,20 +44,20 @@ def optuna(
         Number of Optuna trials. Default 15.
     sample_n : int | None
         Subsample size per trial. Default 5_000. None = full corpus.
-        Recommended for large corpora (> 50k items).
     seed : int
         Random seed for reproducibility.
     study_name : str
         Optuna study identifier.
     storage : str | None
         Optuna storage URI for persistence. None = in-memory.
-        Use "sqlite:///tune.db" to resume interrupted runs.
     eps_low, eps_high : float
         Log-scale search bounds for eps.
     k_low, k_high : int
         Search bounds for k.
-    tau_low, tau_high : float
-        Search bounds for tau.
+    search_tau : float
+        Fixed tau used inside the study's search_batch calls.
+        Default 0.5 (balanced spectral + cosine blend).
+        Not optimised — see EpsTuner docstring for rationale.
     n_probe : int
         Number of anchor queries per trial for the MRR proxy. Default 50.
 
@@ -79,7 +70,7 @@ def optuna(
 
     Examples
     --------
-    Minimal usage — matches the acceptance criteria exactly:
+    Minimal usage:
 
         import numpy as np
         import arrowspace_tuner as arrowspace
@@ -87,33 +78,13 @@ def optuna(
         embeddings = np.load("corpus.npy")
         aspace, gl = arrowspace.optuna(embeddings)
 
-        results = aspace.search(query_embedding, gl, tau=0.8)
+        # tau for search is independent — pass what makes sense for your workload
+        results = aspace.search(query_embedding, gl, tau=0.5)
 
-    With a custom search range:
+    With a custom search_tau:
 
-        aspace, gl = arrowspace.optuna(
-            embeddings,
-            n_trials=30,
-            sample_n=10_000,
-            eps_low=0.5,
-            eps_high=3.0,
-        )
-
-    Inspecting the study after the fact:
-
-        from arrowspace_tuner import EpsTuner
-
-        tuner = EpsTuner(n_trials=15, sample_n=5_000)
-        aspace, gl = tuner.fit(embeddings)
-        print(tuner.best_params)
-        tuner.save_report()
-
-    Resuming an interrupted run:
-
-        aspace, gl = arrowspace.optuna(
-            embeddings,
-            storage="sqlite:///tune.db",
-        )
+        aspace, gl = arrowspace.optuna(embeddings, search_tau=0.3)
+        results = aspace.search(query_embedding, gl, tau=0.3)
     """
     tuner = EpsTuner(
         n_trials   = n_trials,
@@ -125,8 +96,7 @@ def optuna(
         eps_high   = eps_high,
         k_low      = k_low,
         k_high     = k_high,
-        tau_low    = tau_low,
-        tau_high   = tau_high,
+        search_tau = search_tau,
         n_probe    = n_probe,
     )
     return tuner.fit(embeddings)

--- a/src/arrowspace_tuner/core/config.py
+++ b/src/arrowspace_tuner/core/config.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 # Single source of truth for the default number of trials.
 # Referenced by StudyConfig, EpsTuner.__init__, and api.optuna().
 _DEFAULT_N_TRIALS: int = 15
+
+# Fixed tau used by search_batch inside the objective.
+# Not optimised — see rationale in objective.py.
+DEFAULT_SEARCH_TAU: float = 0.5
 
 
 @dataclass
@@ -98,13 +102,19 @@ class StudyConfig:
     k_low, k_high : int
         Bounds for k (nearest neighbours) search.
 
-    Search space — retrieval
-    ------------------------
-    tau_low, tau_high : float
-        Bounds for tau search. tau controls the ArrowSpace search
-        temperature passed to search_batch(). Optimising tau alongside
-        eps and k ensures the graph is evaluated at its best retrieval
-        operating point, not an arbitrary fixed tau.
+    Search tau (fixed, not optimised)
+    ----------------------------------
+    search_tau : float
+        The tau value passed to search_batch() inside every trial.
+        This is NOT optimised by Optuna. Optimising tau alongside eps/k
+        creates a circular reward: low tau makes search_batch behave like
+        pure cosine retrieval, which happens to score highest under the
+        spectral MRR proxy. The result is tau collapsing to its lower
+        bound regardless of corpus geometry.
+
+        Users who want to tune search_tau for their workload should do so
+        separately, after the graph structure (eps, k) has been determined.
+        Default: 0.5 (balanced spectral + cosine blend).
 
     MRR proxy
     ---------
@@ -129,11 +139,10 @@ class StudyConfig:
     k_low:    int   = 3
     k_high:   int   = 40
 
-    # Search space — retrieval
-    tau_low:  float = 0.1
-    tau_high: float = 1.0
+    # Fixed search tau — not part of the Optuna search space
+    search_tau: float = DEFAULT_SEARCH_TAU
 
-    # MRR proxy — 50 gives ~14% s.e., adequate for trial ranking (was 200)
+    # MRR proxy — 50 gives ~14% s.e., adequate for trial ranking
     n_probe:  int   = 50
     max_clusters:   int   = 50
     cluster_radius: float = 0.5

--- a/src/arrowspace_tuner/core/objective.py
+++ b/src/arrowspace_tuner/core/objective.py
@@ -14,7 +14,17 @@ Objective (maximise):
           + W_FIED * log1p(fiedler)      # connectivity health
           + W_VAR  * log1p(var_lambda)   # spectral richness
 
-Hyperparameters optimised by Optuna: eps, k, tau
+Hyperparameters optimised by Optuna: eps, k
+
+Search tau is fixed (not optimised). Rationale:
+    Optimising tau alongside eps/k creates a circular reward. Low tau
+    makes search_batch behave like pure cosine retrieval, which scores
+    highest under the spectral MRR proxy because the proxy itself measures
+    spectral proximity of results. The optimiser collapses tau to its lower
+    bound regardless of corpus geometry, defeating the spectral+cosine blend
+    that is the purpose of ArrowSpace.
+    search_tau is therefore fixed to DEFAULT_SEARCH_TAU (0.5) and can be
+    tuned independently by the user after graph structure is determined.
 
 Pruning checkpoints (MedianPruner in tuner.py):
     step=0  after Fiedler   — cheap proxy for connectivity
@@ -63,7 +73,7 @@ class ArrowSpaceProtocol(Protocol):
     def search_batch(
         self,
         queries: np.ndarray,
-        gl: PyGraphLaplacian ,
+        gl: PyGraphLaplacian,
         tau: float,
     ) -> Sequence[Sequence[tuple[int, float]]]:
         """Run a batch of queries against the index."""
@@ -179,7 +189,6 @@ def build_and_score(
         if trial:
             raise optuna.TrialPruned()
         return 0.0, 0.0, None, None
-    
 
     # ── pruner checkpoint 0: after Fiedler ─────────────────────────────────────
     if trial is not None:
@@ -215,7 +224,8 @@ def make_objective(
     Return ``(objective_fn, best_cache)`` closed over embeddings and cfg.
 
     ``objective_fn`` is passed directly to ``study.optimize()``.
-    It searches over eps, k, and tau simultaneously.
+    It searches over eps and k only. search_tau is fixed to cfg.search_tau
+    and passed directly to search_batch — it is not an Optuna parameter.
 
     ``best_cache`` is a dict updated in-place whenever a trial beats the
     current best score::
@@ -264,21 +274,21 @@ def make_objective(
         n_fixed, size=min(cfg.n_probe, n_fixed), replace=False
     )
 
+    # ── fixed search tau (not optimised) ─────────────────────────────────────
+    search_tau = cfg.search_tau
+
     # ── best-trial cache (#9) ───────────────────────────────────────────────
-    # Only populated when using the full corpus (not a subsample), because
-    # subsample-built objects cannot be returned as the final (aspace, gl).
-    best_cache: dict[str, Any] = {}   # keys: "aspace", "gl", "score" when populated
-    _cache_lock = threading.Lock()  # protect concurrent updates (n_jobs > 1)
+    best_cache: dict[str, Any] = {}
+    _cache_lock = threading.Lock()
 
     def objective(trial: optuna.Trial) -> float:
 
         # ── 1. fixed corpus slice ─────────────────────────────────────────────
         emb_trial = emb_fixed
 
-        # ── 2. suggest hyperparameters ────────────────────────────────────────
+        # ── 2. suggest hyperparameters (eps and k only) ───────────────────────
         k   = trial.suggest_int(  "k",   cfg.k_low,   cfg.k_high)
         eps = trial.suggest_float("eps", cfg.eps_low,  cfg.eps_high, log=True)
-        tau = trial.suggest_float("tau", cfg.tau_low,  cfg.tau_high)
 
         params = BuildParams(
             eps=eps,
@@ -307,15 +317,15 @@ def make_objective(
             emb_trial[probe_idx], dtype=np.float64
         )
 
-        # ── 5. k-NN retrieval via search_batch ────────────────────────────────
+        # ── 5. k-NN retrieval via search_batch (fixed search_tau) ─────────────
         if aspace is None or gl is None:
             raise optuna.TrialPruned()
         try:
-            batch_results = aspace.search_batch(probe_embs, gl, tau)
+            batch_results = aspace.search_batch(probe_embs, gl, search_tau)
         except Exception as exc:
             logger.warning(
-                "Trial %d search_batch failed (eps=%.4f k=%d tau=%.3f): %s",
-                trial.number, params.eps, params.k, tau, exc,
+                "Trial %d search_batch failed (eps=%.4f k=%d search_tau=%.3f): %s",
+                trial.number, params.eps, params.k, search_tau, exc,
             )
             raise optuna.TrialPruned()
 
@@ -360,17 +370,17 @@ def make_objective(
                     best_cache["score"]  = score
 
         # ── 10. log trial attributes ──────────────────────────────────────────
-        trial.set_user_attr("fiedler",    round(fiedler,    8))
-        trial.set_user_attr("var_lambda", round(var_lambda, 8))
-        trial.set_user_attr("mrr_proxy",  round(mrr_proxy,  6))
-        trial.set_user_attr("tau",        round(tau,        6))
-        trial.set_user_attr("n_sample",   len(emb_trial))
-        trial.set_user_attr("n_probe",    len(probe_idx))
+        trial.set_user_attr("fiedler",     round(fiedler,     8))
+        trial.set_user_attr("var_lambda",  round(var_lambda,  8))
+        trial.set_user_attr("mrr_proxy",   round(mrr_proxy,   6))
+        trial.set_user_attr("search_tau",  round(search_tau,  6))
+        trial.set_user_attr("n_sample",    len(emb_trial))
+        trial.set_user_attr("n_probe",     len(probe_idx))
 
         logger.info(
-            "Trial %03d | eps=%.5f k=%2d topk=%2d tau=%.3f | "
+            "Trial %03d | eps=%.5f k=%2d topk=%2d search_tau=%.3f | "
             "fiedler=%.4f var=%.4f mrr=%.4f → score=%.6f",
-            trial.number, params.eps, params.k, params.topk, tau,
+            trial.number, params.eps, params.k, params.topk, search_tau,
             fiedler, var_lambda, mrr_proxy, score,
         )
         return score

--- a/src/arrowspace_tuner/tuner.py
+++ b/src/arrowspace_tuner/tuner.py
@@ -8,11 +8,14 @@ Typical usage:
     aspace, gl = tuner.fit(embeddings)
 
     # inspect results
-    print(tuner.best_params)   # {"eps": 1.2, "k": 14, "tau": 0.8}
+    print(tuner.best_params)   # {"eps": 1.2, "k": 14}
     print(tuner.best_score)
 
     # optional: save full report (requires [report] extra)
     tuner.save_report(out_dir="results")
+
+    # use the recommended search_tau when calling search
+    results = aspace.search(query_embedding, gl, tau=tuner.search_tau)
 """
 from __future__ import annotations
 
@@ -25,12 +28,10 @@ import numpy as np
 import optuna
 
 from .core import BuildParams, StudyConfig, make_objective
-from .core.config import _DEFAULT_N_TRIALS
+from .core.config import _DEFAULT_N_TRIALS, DEFAULT_SEARCH_TAU
 
 logger = logging.getLogger(__name__)
 
-# Silence Optuna's verbose output by default.
-# Users can re-enable with: optuna.logging.set_verbosity(optuna.logging.INFO)
 optuna.logging.set_verbosity(optuna.logging.WARNING)
 
 
@@ -38,14 +39,19 @@ class EpsTuner:
     """
     Hyperparameter discovery for ArrowSpace via Optuna.
 
-    Searches over eps, k, and tau simultaneously using the spectral
-    MRR-Top0 proxy as the objective (query-free, label-agnostic).
+    Searches over eps and k using the spectral MRR-Top0 proxy as the
+    objective (query-free, label-agnostic).
+
+    tau is NOT optimised. It is a search-time parameter controlling the
+    spectral/cosine blend in search_batch(). Optimising it alongside
+    eps/k creates a circular reward (see objective.py for details).
+    Use the ``search_tau`` parameter to set it; the same value is stored
+    on ``tuner.search_tau`` for convenience after fit().
 
     Parameters
     ----------
     n_trials : int
-        Number of Optuna trials. Default 15. More trials = better coverage
-        of the search space at the cost of runtime.
+        Number of Optuna trials. Default 15.
     sample_n : int | None
         Subsample this many embeddings per trial for speed. None = full
         corpus every trial. Recommended 5_000 for corpora > 50k items
@@ -61,33 +67,19 @@ class EpsTuner:
         Log-scale search bounds for eps.
     k_low, k_high : int
         Search bounds for k (number of nearest neighbours).
-    tau_low, tau_high : float
-        Search bounds for tau (ArrowSpace search temperature).
+    search_tau : float
+        Fixed tau passed to search_batch() inside every trial.
+        Not optimised — see class docstring. Default: 0.5.
     n_probe : int
         Number of anchor queries per trial for the MRR proxy.
-        Scales search_batch cost linearly; 50 is the default (~ 14% s.e.).
+        Scales search_batch cost linearly; 50 is the default (~14% s.e.).
     n_jobs : int
         Number of parallel workers. Default 1 (serial, fully reproducible).
-
-        Set to -1 to use all available CPU cores for a ~N× speedup where
-        N = min(n_trials, cpu_count). Typical production usage::
-
-            EpsTuner(n_trials=30, n_jobs=-1)   # parallel, fast
-            EpsTuner(n_trials=15, n_jobs=1)    # serial, reproducible
-
-        Threading safety: each trial runs in a separate thread sharing
-        the same process. The objective closure is stateless, but
-        ArrowSpace's .build() must be thread-safe. If you observe crashes
-        or corrupted results with n_jobs > 1, fall back to n_jobs=1.
-
-        Reproducibility: with n_jobs > 1 the trial execution order is
-        non-deterministic even with a fixed seed, so best_params may vary
-        between runs. Use n_jobs=1 for exact reproducibility.
 
     Attributes (available after .fit())
     ------------------------------------
     best_params : dict[str, Any]
-        Best hyperparameters found: {"eps": float, "k": int, "tau": float}.
+        Best hyperparameters found: {"eps": float, "k": int}.
     best_score : float
         Best composite objective score achieved.
     best_fiedler : float
@@ -96,6 +88,8 @@ class EpsTuner:
         Lambda variance at the best trial (spectral richness).
     best_mrr_proxy : float
         MRR proxy at the best trial (retrieval coherence).
+    search_tau : float
+        The tau value used during the study — pass this to aspace.search().
     study : optuna.Study
         The raw Optuna study object for custom analysis.
     """
@@ -112,8 +106,7 @@ class EpsTuner:
         eps_high:   float        = 4.0,
         k_low:      int          = 3,
         k_high:     int          = 40,
-        tau_low:    float        = 0.1,
-        tau_high:   float        = 1.0,
+        search_tau: float        = DEFAULT_SEARCH_TAU,
         n_probe:    int          = 50,
         n_jobs:     int          = 1,
     ) -> None:
@@ -127,11 +120,11 @@ class EpsTuner:
             eps_high   = eps_high,
             k_low      = k_low,
             k_high     = k_high,
-            tau_low    = tau_low,
-            tau_high   = tau_high,
+            search_tau = search_tau,
             n_probe    = n_probe,
             n_jobs     = n_jobs,
         )
+        self.search_tau: float = search_tau
 
         # Results — populated by .fit()
         self.best_params:     dict[str, Any] | None = None
@@ -153,8 +146,7 @@ class EpsTuner:
         Parameters
         ----------
         embeddings : np.ndarray
-            Shape (N, D) float64 corpus embeddings. N should be at least
-            a few hundred for meaningful spectral analysis.
+            Shape (N, D) float64 corpus embeddings.
 
         Returns
         -------
@@ -168,23 +160,16 @@ class EpsTuner:
         ValueError
             If embeddings are not a 2D array.
         RuntimeError
-            If all trials were pruned (corpus too small or search bounds
-            too narrow — try widening eps_low/eps_high).
+            If all trials were pruned.
         """
         embeddings = self._validate(embeddings)
 
         cfg = self._cfg
         logger.info(
-            "Starting EpsTuner: n_trials=%d  sample_n=%s  seed=%d  n_jobs=%d",
-            cfg.n_trials, cfg.sample_n, cfg.seed, cfg.n_jobs,
+            "Starting EpsTuner: n_trials=%d  sample_n=%s  seed=%d  n_jobs=%d  search_tau=%.3f",
+            cfg.n_trials, cfg.sample_n, cfg.seed, cfg.n_jobs, cfg.search_tau,
         )
 
-        # ── sampler: GPSampler → TPE multivariate fallback (#4) ─────────────────
-        # GPSampler (Gaussian Process / BoTorch) is the best choice for
-        # small trial budgets (≤30) on a low-dimensional continuous space.
-        # It requires optuna[botorch]; if that is not installed we fall back
-        # to TPESampler with multivariate=True and a reduced n_startup_trials
-        # so the tree model gets as many informed trials as possible.
         try:
             from optuna.samplers import GPSampler
             sampler: optuna.samplers.BaseSampler = GPSampler(
@@ -195,8 +180,8 @@ class EpsTuner:
         except ImportError:
             sampler = optuna.samplers.TPESampler(
                 seed             = cfg.seed,
-                n_startup_trials = 4,       # default 10 → 4: more informed trials
-                multivariate     = True,    # joint posterior over (eps, k, tau)
+                n_startup_trials = 4,
+                multivariate     = True,
                 group            = True,
             )
             logger.info(
@@ -204,13 +189,11 @@ class EpsTuner:
                 "[install optuna[botorch] for GPSampler]"
             )
 
-        # ── pruner ──────────────────────────────────────────────────────────────
         pruner = optuna.pruners.MedianPruner(
             n_startup_trials = 4,
             n_warmup_steps   = 0,
         )
 
-        # ── create study ─────────────────────────────────────────────────────────
         study = optuna.create_study(
             direction      = "maximize",
             study_name     = cfg.study_name,
@@ -220,10 +203,6 @@ class EpsTuner:
             load_if_exists = cfg.storage is not None,
         )
 
-        # ── warm-start: enqueue one known-good anchor trial (#4) ───────────────
-        # Gives the surrogate a reasonable starting point so trial 0 is
-        # never wasted on an arbitrary corner of the search space.
-        # Only enqueue when starting fresh (not resuming from storage).
         completed_so_far = [
             t for t in study.trials
             if t.state == optuna.trial.TrialState.COMPLETE
@@ -231,19 +210,16 @@ class EpsTuner:
         if not completed_so_far:
             study.enqueue_trial(
                 {
-                    "eps": max(cfg.eps_low,  min(cfg.eps_high,  1.0)),
-                    "k":   max(cfg.k_low,    min(cfg.k_high,    15)),
-                    "tau": max(cfg.tau_low,  min(cfg.tau_high,  0.5)),
+                    "eps": max(cfg.eps_low, min(cfg.eps_high, 1.0)),
+                    "k":   max(cfg.k_low,   min(cfg.k_high,   15)),
                 },
                 skip_if_exists=True,
             )
 
-        # ── run optimisation ────────────────────────────────────────────────────
         objective_fn, best_cache = make_objective(embeddings, cfg)
         objective: Callable[[optuna.Trial], float] = objective_fn  # type: ignore[assignment]
         study.optimize(objective, n_trials=cfg.n_trials, n_jobs=cfg.n_jobs)
 
-        # ── guard: all trials pruned ───────────────────────────────────────────
         completed = [
             t for t in study.trials
             if t.state == optuna.trial.TrialState.COMPLETE
@@ -254,7 +230,6 @@ class EpsTuner:
                 "Try widening eps_low/eps_high or increasing sample_n."
             )
 
-        # ── store results ─────────────────────────────────────────────────────
         best             = study.best_trial
         self.study       = study
         self.best_params     = best.params
@@ -264,20 +239,14 @@ class EpsTuner:
         self.best_mrr_proxy  = best.user_attrs.get("mrr_proxy")
 
         logger.info(
-            "EpsTuner finished | best score=%.6f | eps=%.5f k=%d tau=%.3f",
+            "EpsTuner finished | best score=%.6f | eps=%.5f k=%d",
             self.best_score,
             self.best_params["eps"],
             self.best_params["k"],
-            self.best_params["tau"],
         )
 
-        # ── final build: use cached objects if available (#9) ──────────────────
-        # When sample_n=None every trial built on the full corpus, so the
-        # best trial's aspace+gl are already correct. Skip _final_build.
         if best_cache:
-            logger.info(
-                "Returning cached best-trial objects (skipping redundant build)"
-            )
+            logger.info("Returning cached best-trial objects (skipping redundant build)")
             return best_cache["aspace"], best_cache["gl"]
 
         return self._final_build(embeddings)
@@ -288,21 +257,6 @@ class EpsTuner:
 
         Requires the [report] extra:
             pip install arrowspace-tuner[report]
-
-        Parameters
-        ----------
-        out_dir : str
-            Root directory. Files land in out_dir/<study_name>/<timestamp>/.
-
-        Returns
-        -------
-        Path
-            The timestamped run directory where files were saved.
-
-        Raises
-        ------
-        RuntimeError
-            If called before .fit().
         """
         if self.study is None:
             raise RuntimeError("Call .fit() before .save_report().")
@@ -313,11 +267,6 @@ class EpsTuner:
     # ── private helpers ──────────────────────────────────────────────────────────
 
     def _validate(self, embeddings: np.ndarray) -> np.ndarray:
-        """
-        Validate and cast embeddings to float64.
-
-        Returns the (possibly cast) array so callers always work with float64.
-        """
         if not isinstance(embeddings, np.ndarray):
             raise ValueError(
                 f"embeddings must be np.ndarray, got {type(embeddings).__name__}"
@@ -336,9 +285,7 @@ class EpsTuner:
     def _final_build(self, embeddings: np.ndarray) -> tuple[object, object]:
         """
         Rebuild ArrowSpace once with the best params found by the study.
-        This is the (aspace, gl) pair returned to the user.
-        Only called when sample_n is set (subsample path), because in that
-        case the trial objects were built on a subset, not the full corpus.
+        Only called when sample_n is set (subsample path).
         """
         from arrowspace import ArrowSpaceBuilder
 
@@ -377,6 +324,6 @@ class EpsTuner:
             f"n_trials={self._cfg.n_trials}, "
             f"eps=[{self._cfg.eps_low}, {self._cfg.eps_high}], "
             f"k=[{self._cfg.k_low}, {self._cfg.k_high}], "
-            f"tau=[{self._cfg.tau_low}, {self._cfg.tau_high}], "
+            f"search_tau={self.search_tau}, "
             f"{status})"
         )


### PR DESCRIPTION
## Problem

`tau` was being optimised alongside `eps` and `k`, but the objective function created a **circular reward**: low tau makes `search_batch` behave like pure cosine retrieval, which happens to score highest under the spectral MRR proxy (because the proxy measures spectral proximity of results — the same thing that pure cosine retrieval optimises for).

The result: tau collapsed to its lower bound (~0.11) in every run, regardless of corpus geometry, nearly disabling the spectral component of ArrowSpace search entirely.

From the CVE trials.csv:
| tau | mrr_proxy | score |
|-----|-----------|-------|
| 0.114 | 2.896 | 2.138 |
| 0.135 | 2.886 | 2.127 |
| ... | ... | ... |
| 1.757 | 0.566 | 0.503 |

Tau was **monotonically correlated with score** — pure boundary-chasing, not genuine optimisation.

## Fix

Tau is removed from the Optuna search space. It is now a **fixed constant** (`DEFAULT_SEARCH_TAU = 0.5`) passed to `search_batch` inside every trial. Users can override it via the `search_tau` parameter and use `tuner.search_tau` to get it back after `fit()`.

## Changes

- **`config.py`**: `tau_low` / `tau_high` removed from `StudyConfig`; `search_tau: float = 0.5` added; `DEFAULT_SEARCH_TAU` constant exported
- **`objective.py`**: `trial.suggest_float("tau", ...)` removed; `search_tau = cfg.search_tau` used as fixed constant; docstring updated with full rationale; `user_attr` key renamed `tau` → `search_tau`
- **`tuner.py`**: `tau_low` / `tau_high` kwargs removed from `EpsTuner.__init__`; `search_tau` kwarg added; `tuner.search_tau` attribute exposed; warm-start anchor updated; log line updated; `__repr__` updated
- **`api.py`**: `tau_low` / `tau_high` removed; `search_tau` added
- **`CHANGELOG.md`**: v0.3.0 entry with migration notes

## Migration

```python
# Before
tuner = EpsTuner(tau_low=0.1, tau_high=1.0)
aspace, gl = tuner.fit(embeddings)
tau = tuner.best_params["tau"]  # was in best_params

# After
tuner = EpsTuner(search_tau=0.5)  # or omit for default
aspace, gl = tuner.fit(embeddings)
tau = tuner.search_tau  # dedicated attribute
results = aspace.search(query, gl, tau=tuner.search_tau)
```
